### PR TITLE
Don't call alert

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,6 @@ export default class Loader extends React.Component {
           height,
           width 
       }
-      alert(color)
       return (<div>{this.svgRenderer(type)}</div>);
   }
 }


### PR DESCRIPTION
Don't call `alert`. It was probably included for debugging purposes?