### PR TITLE
Removing `alert` from `render`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,6 @@ export default class Loader extends React.Component {
           height,
           width 
       }
-      alert(color)
       return (<div>{this.svgRenderer(type)}</div>);
   }
 }


### PR DESCRIPTION
I'm pretty sure that shouldn't be there.