### PR TITLE
Fix label propType in Plane.js

### DIFF
--- a/dist/loader/Plane.js
+++ b/dist/loader/Plane.js
@@ -67,7 +67,7 @@
   Plane.propTypes = {
     secondaryColor: _propTypes2.default.string,
     color: _propTypes2.default.string,
-    label: _propTypes2.default
+    label: _propTypes2.default.string
   };
 
   Plane.defaultProps = {

--- a/src/loader/Plane.js
+++ b/src/loader/Plane.js
@@ -34,7 +34,7 @@ export const Plane = props => (
 Plane.propTypes = {
   secondaryColor: PropTypes.string,
   color: PropTypes.string,
-  label: PropTypes
+  label: PropTypes.string
 };
 
 Plane.defaultProps = {


### PR DESCRIPTION
This fixes the label propType that was causing an error expecting label to be a function instead of string.