### PR TITLE
Adds Demo Link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ yarn add react-loader-spinner
 ```
 
 #  Demo
-[View in page]
+[View in page](https://mhnpd.github.io/react-loader-spinner/)
 
 
 ### Usage


### PR DESCRIPTION
I was visiting this library in NPM and the demo link was missing. So I wanted to fix this little bug to enhance user experience. Can you please merge this with the label `hacktoberfest-accepted` 😉 