### PR TITLE
Allow for react 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "build-storybook": "build-storybook"
   },
   "devDependencies": {
-    "react": "^16.13.1",
-    "react-is": "^16.13.1",
-    "react-dom": "^16.13.1",
+    "react": "^16.13.1 || >= 17.0.0",
+    "react-is": "^16.13.1 || >= 17.0.0",
+    "react-dom": "^16.13.1 || >= 17.0.0",
     "@babel/cli": "^7.11.6",
     "babel-loader": "^8.1.0",
     "@babel/core": "^7.11.6",


### PR DESCRIPTION
Add an or condition for the devDependencies so that projects requiring React 17.0.0 or greater can use this package. 