### PR TITLE
generate esm code addition to cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "unpkg": "dist/index.js",
   "jsdelivr": "dist/index.js",
   "main": "dist/index.js",
+  "module": "dist/esm/index.js",
+  "exports": {
+    "require": "./dist/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "types": "dist/index.d.ts",
   "author": {
     "name": "Mohan Upadhyay",
@@ -22,7 +27,9 @@
     "react"
   ],
   "scripts": {
-    "build": "yarn clean && tsc && yarn copy-files",
+    "build": "yarn clean && yarn build:cjs && yarn build:esm && yarn copy-files",
+    "build:esm": "tsc --module es6 --outdir ./dist/esm/",
+    "build:cjs": "tsc --module commonjs --outdir  ./dist/",
     "build:watch": "tsc --watch",
     "typecheck": "tsc --noEmit --skipLibCheck",
     "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,8 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es5",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "lib": ["es2017", "es7", "es6", "dom"],                                      /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "target": "es5",                                     /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": ["es2017", "es7", "es6", "dom"],              /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
@@ -24,9 +24,9 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
     /* Modules */
-    "module": "es6",                                /* Specify what module code is generated. */
+    "module": "commonjs",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node",                          /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
fixes #111

But there are some beauty errors:
- [ ] Types are generated also in the `esm` folder

![grafik](https://user-images.githubusercontent.com/3897725/150433468-a7b414ed-c48a-492e-ad92-6bcee0d9f8f7.png)


