### PR TITLE
Fix viewbox calculations in Oval

### DIFF
--- a/src/loader/Oval.tsx
+++ b/src/loader/Oval.tsx
@@ -40,8 +40,8 @@ const getViewBoxSize = (
   radius: number,
 ): string => {
   const maxStrokeWidth = Math.max(strokeWidth, secondaryStrokeWidth)
-  const startingPoint = -radius - maxStrokeWidth / 2
-  const endpoint = Math.abs(startingPoint) * 2
+  const startingPoint = -radius - (maxStrokeWidth / 2) + 1
+  const endpoint = (radius * 2) + maxStrokeWidth
   return [startingPoint, startingPoint, endpoint, endpoint].join(' ')
 }
 


### PR DESCRIPTION
Adding 1 to the starting point coordinates appears to fix #110.

<img width="151" alt="Screen Shot 2022-01-21 at 3 21 40 AM" src="https://user-images.githubusercontent.com/8262173/150491938-1ae3cc35-293d-4539-8dfc-dcfbf9b8fceb.png">
