### PR TITLE
Fix npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,13 +9,21 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - name: Checkout code
+        uses: actions/checkout@v1
+      - name: Install Node
+        uses: actions/setup-node@v1
         with:
           node-version: 14
-      - run: npm install
-      - run: npm test
-      - run: npm build
-      - uses: JS-DevTools/npm-publish@v1
+      - name: Install yarn
+        run: npm install -g yarn
+      - name: Install packages
+        run: yarn install
+      - name: Run tests
+        run: yarn test
+      - name: Build TypeScript code
+        run: yarn build
+      - name: Publish to npm
+        uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -93,8 +93,6 @@ react-loader-spinner component has the following types of spinners.
 ### Here are the list of the task for which we want PR:
 
 - Rings spinner is not supported in Safari
-- Fix npm publish script
-- 
 
 ## License
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
     /* Modules */
     "module": "es6",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node",                          /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
Fixes #115

Changes:
- Update `moduleResolution` to `node` so that `yarn build` completes successfully.
- Update `npm-publish.yml` to use `yarn` and build the TypeScript code properly.
- Remove the note about the npm publish script from the README.

I tested this by running the workflow on my fork:

![chrome_I3eYnfKOfj](https://user-images.githubusercontent.com/8262173/150667222-ea372a6f-7110-4953-aaaa-b567d081d450.png)
