### PR TITLE
Update Doc for RevolvingDot and Puff

### DIFF
--- a/docs/components/puff.mdx
+++ b/docs/components/puff.mdx
@@ -8,7 +8,7 @@ import PropsTable from '../../src/components/props-table'
 <Puff
   height="80"
   width="80"
-  radisu={1}
+  radius={1}
   color="#4fa94d"
   ariaLabel="puff-loading"
   wrapperStyle={{}}

--- a/docs/components/revolving-dot.mdx
+++ b/docs/components/revolving-dot.mdx
@@ -12,7 +12,6 @@ import PropsTable from '../../src/components/props-table'
   color="#4fa94d"
   secondaryColor=''
   ariaLabel="revolving-dot-loading"
-  radius="5"
   wrapperStyle={{}}
   wrapperClass=""
   visible={true}


### PR DESCRIPTION
# This fixes Typos in `revolving-dot.md` and `puff.md` 

### Revolving dot
 
- The example component contained `radius` two times, Made It only one.

### Puff

- In the example component, the spelling of `radius` was wrong, fixed it.