### PR TITLE
Fix:revolving dot issue #140

### DIFF
--- a/src/loader/RevolvingDot.tsx
+++ b/src/loader/RevolvingDot.tsx
@@ -26,8 +26,8 @@ const RevolvingDot: FunctionComponent<RevolvingDotProps> = ({
   >
     <svg
       version="1.1"
-      width={width}
-      height={height}
+      width={`calc(${radius} * 2.5)`}
+      height={`calc(${radius} * 2.5)`}
       xmlns="http://www.w3.org/2000/svg"
       x="0px"
       y="0px"
@@ -37,17 +37,22 @@ const RevolvingDot: FunctionComponent<RevolvingDotProps> = ({
         fill="none"
         stroke={color}
         strokeWidth="4"
-        cx="50"
-        cy="50"
-        r={Number(`${radius}`) + 38}
+        // cx={`calc(${width} / 2)`}
+        // cy={`calc(${height} / 2)`}
+        cx={`calc(${radius} * 1.28)`}
+        cy={`calc(${radius} * 1.28)`}
+        // r={Number(`${radius}`) + 38}
+        r={radius}
         style={{ opacity: 0.5 }}
       />
-      <circle
+      {/* <circle
         fill={color}
         stroke={color}
         strokeWidth="3"
-        cx="8"
-        cy="54"
+        // cx="8"
+        // cy="54"
+        cx={`calc(${width} / 2)`}
+        cy={`calc(${radius} * 2)`}
         r={radius}
       >
         <animateTransform
@@ -57,8 +62,8 @@ const RevolvingDot: FunctionComponent<RevolvingDotProps> = ({
           from="0 50 48"
           to="360 50 52"
           repeatCount="indefinite"
-        />
-      </circle>
+        /> 
+      </circle>  */}
     </svg>
   </div>
 )

--- a/src/loader/RevolvingDot.tsx
+++ b/src/loader/RevolvingDot.tsx
@@ -5,12 +5,14 @@ import { BaseProps, DEFAULT_COLOR, DEFAULT_WAI_ARIA_ATTRIBUTE } from '../type'
 interface RevolvingDotProps extends BaseProps {
   radius?: string | number
   secondaryColor?: string
+  strokeWidth?: string | number
 }
 
 const RevolvingDot: FunctionComponent<RevolvingDotProps> = ({
   height = 100,
   width = 100,
   radius = 6,
+  strokeWidth = 4,
   color = DEFAULT_COLOR,
   ariaLabel = 'revolving-dot-loading',
   wrapperStyle,
@@ -36,7 +38,7 @@ const RevolvingDot: FunctionComponent<RevolvingDotProps> = ({
       <circle
         fill="none"
         stroke={color}
-        strokeWidth="4"
+        strokeWidth={strokeWidth}
         // cx={`calc(${width} / 2)`}
         // cy={`calc(${height} / 2)`}
         cx={`calc(${radius} * 1.28)`}
@@ -45,25 +47,35 @@ const RevolvingDot: FunctionComponent<RevolvingDotProps> = ({
         r={radius}
         style={{ opacity: 0.5 }}
       />
-      {/* <circle
+      <circle
         fill={color}
         stroke={color}
         strokeWidth="3"
         // cx="8"
         // cy="54"
-        cx={`calc(${width} / 2)`}
-        cy={`calc(${radius} * 2)`}
-        r={radius}
+        //==============================
+        //=============================
+        // cx={`calc(${width} / 2)`}
+        // cy={`calc(${radius} * 2)`}
+
+        // cy={`calc(${radius} / 3)`}
+        // r={`calc(${radius} / 3.5)`}
+        cx={`calc(${radius} * 1.28)`}
+        cy={`calc(${radius} / 3.5)`}
+        r={`calc(${radius} / 5)`}
+        style={{ transformOrigin: '50% 50%' }}
       >
         <animateTransform
           attributeName="transform"
           dur="2s"
           type="rotate"
-          from="0 50 48"
-          to="360 50 52"
+          // from="0 50 48"
+          // to="360 50 52"
+          from="0"
+          to="360"
           repeatCount="indefinite"
-        /> 
-      </circle>  */}
+        />
+      </circle>
     </svg>
   </div>
 )

--- a/src/loader/RevolvingDot.tsx
+++ b/src/loader/RevolvingDot.tsx
@@ -9,11 +9,10 @@ interface RevolvingDotProps extends BaseProps {
 }
 
 const RevolvingDot: FunctionComponent<RevolvingDotProps> = ({
-  height = 100,
-  width = 100,
   radius = 6,
   strokeWidth = 4,
   color = DEFAULT_COLOR,
+  secondaryColor,
   ariaLabel = 'revolving-dot-loading',
   wrapperStyle,
   wrapperClass,
@@ -37,13 +36,10 @@ const RevolvingDot: FunctionComponent<RevolvingDotProps> = ({
     >
       <circle
         fill="none"
-        stroke={color}
+        stroke={secondaryColor || color}
         strokeWidth={strokeWidth}
-        // cx={`calc(${width} / 2)`}
-        // cy={`calc(${height} / 2)`}
         cx={`calc(${radius} * 1.28)`}
         cy={`calc(${radius} * 1.28)`}
-        // r={Number(`${radius}`) + 38}
         r={radius}
         style={{ opacity: 0.5 }}
       />
@@ -51,15 +47,6 @@ const RevolvingDot: FunctionComponent<RevolvingDotProps> = ({
         fill={color}
         stroke={color}
         strokeWidth="3"
-        // cx="8"
-        // cy="54"
-        //==============================
-        //=============================
-        // cx={`calc(${width} / 2)`}
-        // cy={`calc(${radius} * 2)`}
-
-        // cy={`calc(${radius} / 3)`}
-        // r={`calc(${radius} / 3.5)`}
         cx={`calc(${radius} * 1.28)`}
         cy={`calc(${radius} / 3.5)`}
         r={`calc(${radius} / 5)`}
@@ -69,8 +56,6 @@ const RevolvingDot: FunctionComponent<RevolvingDotProps> = ({
           attributeName="transform"
           dur="2s"
           type="rotate"
-          // from="0 50 48"
-          // to="360 50 52"
           from="0"
           to="360"
           repeatCount="indefinite"

--- a/src/loader/RevolvingDot.tsx
+++ b/src/loader/RevolvingDot.tsx
@@ -3,14 +3,14 @@ import { getDefaultStyle } from '../helpers'
 import { BaseProps, DEFAULT_COLOR, DEFAULT_WAI_ARIA_ATTRIBUTE } from '../type'
 
 interface RevolvingDotProps extends BaseProps {
-  radius?: string | number
+  radius?: number
   secondaryColor?: string
-  strokeWidth?: string | number
+  strokeWidth?: number
 }
 
 const RevolvingDot: FunctionComponent<RevolvingDotProps> = ({
-  radius = 6,
-  strokeWidth = 4,
+  radius = 45,
+  strokeWidth = 5,
   color = DEFAULT_COLOR,
   secondaryColor,
   ariaLabel = 'revolving-dot-loading',

--- a/test/loader/RevolvingDot.spec.tsx
+++ b/test/loader/RevolvingDot.spec.tsx
@@ -18,17 +18,17 @@ describe('RevolvingDot Loader', () => {
 
     const svg = screen.getByTestId(svgTestId)
     expect(svg).toBeDefined()
-    expect(svg).toHaveAttribute('width', `calc(6 * 2.5)`)
-    expect(svg).toHaveAttribute('height', `calc(6 * 2.5)`)
+    expect(svg).toHaveAttribute('width', `calc(45 * 2.5)`)
+    expect(svg).toHaveAttribute('height', `calc(45 * 2.5)`)
 
     svg.querySelectorAll('circle').forEach((circle, index) => {
       if (index === 0) {
         expect(circle).toHaveAttribute('stroke', DEFAULT_COLOR)
-        expect(circle).toHaveAttribute('r', '6')
+        expect(circle).toHaveAttribute('r', '45')
       } else if (index === 1) {
         expect(circle).toHaveAttribute('stroke', DEFAULT_COLOR)
         expect(circle).toHaveAttribute('fill', DEFAULT_COLOR)
-        expect(circle).toHaveAttribute('r', `calc(6 / 5)`)
+        expect(circle).toHaveAttribute('r', `calc(45 / 5)`)
       }
     })
   })

--- a/test/loader/RevolvingDot.spec.tsx
+++ b/test/loader/RevolvingDot.spec.tsx
@@ -18,16 +18,17 @@ describe('RevolvingDot Loader', () => {
 
     const svg = screen.getByTestId(svgTestId)
     expect(svg).toBeDefined()
-    expect(svg).toHaveAttribute('width', '100')
-    expect(svg).toHaveAttribute('height', '100')
+    expect(svg).toHaveAttribute('width', `calc(6 * 2.5)`)
+    expect(svg).toHaveAttribute('height', `calc(6 * 2.5)`)
 
     svg.querySelectorAll('circle').forEach((circle, index) => {
       if (index === 0) {
         expect(circle).toHaveAttribute('stroke', DEFAULT_COLOR)
+        expect(circle).toHaveAttribute('r', '6')
       } else if (index === 1) {
         expect(circle).toHaveAttribute('stroke', DEFAULT_COLOR)
         expect(circle).toHaveAttribute('fill', DEFAULT_COLOR)
-        expect(circle).toHaveAttribute('r', '6')
+        expect(circle).toHaveAttribute('r', `calc(6 / 5)`)
       }
     })
   })


### PR DESCRIPTION
## This fixes Revolving dot issue #140 

Both the circles are now scaling up and down properly without getting cropped.


![revolving fix](https://user-images.githubusercontent.com/66154210/188282710-2f98f980-480e-4778-9b1b-8b8266c1070d.PNG)


### Some additions 

- Added support for secondary color
- Added support to change stroke width
