### PR TITLE
Add stroke width to TailSpin circle (Issue #144)

### DIFF
--- a/src/loader/TailSpin.tsx
+++ b/src/loader/TailSpin.tsx
@@ -17,59 +17,65 @@ export const TailSpin: FunctionComponent<TailSpinProps> = ({
   wrapperStyle,
   wrapperClass,
   visible = true,
-}): ReactElement => (
-  <div
-    style={{ ...getDefaultStyle(visible), ...wrapperStyle }}
-    className={wrapperClass}
-    data-testid="tail-spin-loading"
-    aria-label={ariaLabel}
-    {...DEFAULT_WAI_ARIA_ATTRIBUTE}
-  >
-    <svg
-      width={width}
-      height={height}
-      viewBox={`0 0 ${strokeWidth as number + 36} ${strokeWidth as number + 36}`}
-      xmlns="http://www.w3.org/2000/svg"
-      data-testid="tail-spin-svg"
+}): ReactElement => {
+  const strokeWidthNum = parseInt(String(strokeWidth));
+  const viewBoxValue = strokeWidthNum + 36;
+  const halfStrokeWidth = strokeWidthNum / 2;
+  const processedRadius = halfStrokeWidth + parseInt(String(radius)) - 1;
+  return (
+    <div
+      style={{ ...getDefaultStyle(visible), ...wrapperStyle }}
+      className={wrapperClass}
+      data-testid="tail-spin-loading"
+      aria-label={ariaLabel}
+      {...DEFAULT_WAI_ARIA_ATTRIBUTE}
     >
-      <defs>
-        <linearGradient x1="8.042%" y1="0%" x2="65.682%" y2="23.865%" id="a">
-          <stop stopColor={color} stopOpacity="0" offset="0%" />
-          <stop stopColor={color} stopOpacity=".631" offset="63.146%" />
-          <stop stopColor={color} offset="100%" />
-        </linearGradient>
-      </defs>
-      <g fill="none" fillRule="evenodd">
-        <g transform={`translate(${strokeWidth as number / 2} ${strokeWidth as number / 2})`}>
-          <path
-            d="M36 18c0-9.94-8.06-18-18-18"
-            id="Oval-2"
-            stroke={color}
-            strokeWidth={strokeWidth}
-          >
-            <animateTransform
-              attributeName="transform"
-              type="rotate"
-              from="0 18 18"
-              to="360 18 18"
-              dur="0.9s"
-              repeatCount="indefinite"
-            />
-          </path>
-          <circle fill="#fff" cx="36" cy="18" r={(strokeWidth as number / 2) + (radius as number - 1)}>
-            <animateTransform
-              attributeName="transform"
-              type="rotate"
-              from="0 18 18"
-              to="360 18 18"
-              dur="0.9s"
-              repeatCount="indefinite"
-            />
-          </circle>
+      <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${viewBoxValue} ${viewBoxValue}`}
+        xmlns="http://www.w3.org/2000/svg"
+        data-testid="tail-spin-svg"
+      >
+        <defs>
+          <linearGradient x1="8.042%" y1="0%" x2="65.682%" y2="23.865%" id="a">
+            <stop stopColor={color} stopOpacity="0" offset="0%" />
+            <stop stopColor={color} stopOpacity=".631" offset="63.146%" />
+            <stop stopColor={color} offset="100%" />
+          </linearGradient>
+        </defs>
+        <g fill="none" fillRule="evenodd">
+          <g transform={`translate(${halfStrokeWidth} ${halfStrokeWidth})`}>
+            <path
+              d="M36 18c0-9.94-8.06-18-18-18"
+              id="Oval-2"
+              stroke={color}
+              strokeWidth={strokeWidth}
+            >
+              <animateTransform
+                attributeName="transform"
+                type="rotate"
+                from="0 18 18"
+                to="360 18 18"
+                dur="0.9s"
+                repeatCount="indefinite"
+              />
+            </path>
+            <circle fill="#fff" cx="36" cy="18" r={processedRadius}>
+              <animateTransform
+                attributeName="transform"
+                type="rotate"
+                from="0 18 18"
+                to="360 18 18"
+                dur="0.9s"
+                repeatCount="indefinite"
+              />
+            </circle>
+          </g>
         </g>
-      </g>
-    </svg>
-  </div>
-)
+      </svg>
+    </div>
+  )
+}
 
 export default TailSpin

--- a/src/loader/TailSpin.tsx
+++ b/src/loader/TailSpin.tsx
@@ -3,12 +3,14 @@ import { getDefaultStyle } from '../helpers'
 import { BaseProps, DEFAULT_COLOR, DEFAULT_WAI_ARIA_ATTRIBUTE } from '../type'
 
 interface TailSpinProps extends BaseProps {
-  radius?: string | number
+  radius?: string | number,
+  strokeWidth?: string | number
 }
 
 export const TailSpin: FunctionComponent<TailSpinProps> = ({
   height = 80,
   width = 80,
+  strokeWidth = 2,
   radius = 1,
   color = DEFAULT_COLOR,
   ariaLabel = 'tail-spin-loading',
@@ -26,7 +28,7 @@ export const TailSpin: FunctionComponent<TailSpinProps> = ({
     <svg
       width={width}
       height={height}
-      viewBox="0 0 38 38"
+      viewBox={`0 0 ${strokeWidth as number + 36} ${strokeWidth as number + 36}`}
       xmlns="http://www.w3.org/2000/svg"
       data-testid="tail-spin-svg"
     >
@@ -38,12 +40,12 @@ export const TailSpin: FunctionComponent<TailSpinProps> = ({
         </linearGradient>
       </defs>
       <g fill="none" fillRule="evenodd">
-        <g transform="translate(1 1)">
+        <g transform={`translate(${strokeWidth as number / 2} ${strokeWidth as number / 2})`}>
           <path
             d="M36 18c0-9.94-8.06-18-18-18"
             id="Oval-2"
             stroke={color}
-            strokeWidth="2"
+            strokeWidth={strokeWidth}
           >
             <animateTransform
               attributeName="transform"
@@ -54,7 +56,7 @@ export const TailSpin: FunctionComponent<TailSpinProps> = ({
               repeatCount="indefinite"
             />
           </path>
-          <circle fill="#fff" cx="36" cy="18" r={radius}>
+          <circle fill="#fff" cx="36" cy="18" r={(strokeWidth as number / 2) + (radius as number - 1)}>
             <animateTransform
               attributeName="transform"
               type="rotate"

--- a/test/loader/TailSpin.spec.tsx
+++ b/test/loader/TailSpin.spec.tsx
@@ -30,6 +30,7 @@ describe('TailSpin', () => {
     })
     svg.querySelectorAll('path').forEach(path => {
       expect(path).toHaveAttribute('stroke', DEFAULT_COLOR)
+      expect(path).toHaveAttribute('stroke-width', "2")
     })
   })
 
@@ -43,6 +44,7 @@ describe('TailSpin', () => {
         wrapperClass="test-class"
         wrapperStyle={{ opacity: '1' }}
         radius={10}
+        strokeWidth={3}
       />
     )
     const component = screen.getByTestId(wrapperTestId)
@@ -64,10 +66,11 @@ describe('TailSpin', () => {
     })
 
     svg.querySelectorAll('circle').forEach(circle => {
-      expect(circle).toHaveAttribute('r', '10')
+      expect(circle).toHaveAttribute('r', '10.5') // r-1 + stroke-width/2
     })
     svg.querySelectorAll('path').forEach(path => {
       expect(path).toHaveAttribute('stroke', 'red')
+      expect(path).toHaveAttribute('stroke-width','3')
     })
   })
 


### PR DESCRIPTION
I've added a stroke width property to the TailSpin Circle. You can now change the thickness of the components. I've also added the necessary tests. All the is left now is to document it, but I don't know how to change the doc.

# Preview
![Screenshot 2022-12-24 at 12-02-53 React App](https://user-images.githubusercontent.com/99157490/209445386-193f53bf-2b89-49bd-88f0-482a1c4d5e95.png)
![Screenshot 2022-12-24 at 12-03-10 React App](https://user-images.githubusercontent.com/99157490/209445388-2d42384d-569a-4787-9327-2a5ee702f850.png)
