### PR TITLE
Fix DNA live editor on documentation

### DIFF
--- a/docs/docs/components/dna.mdx
+++ b/docs/docs/components/dna.mdx
@@ -7,7 +7,7 @@ import { getPropsTableData} from '../../src/components/helpers'
 # DNA
 
 ```jsx live
-<Dna
+<DNA
   visible={true}
   height="80"
   width="80"


### PR DESCRIPTION
Before, the DNA documentation was displaying `ReferenceError: Dna is not defined` since the component was using uppercase only on the first letter.
Now, this is fixed by changing the component to be all in uppercase.