### PR TITLE
Fix small bug with Props' header not being shown in docs/blocks.mdx

### DIFF
--- a/docs/docs/components/blocks.mdx
+++ b/docs/docs/components/blocks.mdx
@@ -28,6 +28,9 @@ import { Blocks } from 'react-loader-spinner'
   <LiveEditor />
   <LiveError />
 </LiveProvider>
---- ## Props
+
+--- 
+
+## Props
 
 <PropsTable properties={[...getPropsTableData('blocks', ['colors'])]} />


### PR DESCRIPTION
Fix the small typo causing the Props' header not being shown in docs
![image](https://github.com/mhnpd/react-loader-spinner/assets/1651451/c4c510e2-c1db-4c34-b1d8-cd5377d66d47)
